### PR TITLE
[WIP] Fix default shell on macOS

### DIFF
--- a/lib/fvim-osx-launcher
+++ b/lib/fvim-osx-launcher
@@ -1,11 +1,4 @@
 #!/usr/bin/env bash
-source /etc/profile
-source ~/.bash_profile
-logger "FVim: Starting. env is: $(env)"
-new_bash=$(which bash)
-export SHELL=$new_bash
-logger "FVim: new bash location is: $new_bash"
+eval `/usr/libexec/path_helper -s`
 fvim_exe="$(dirname "$0")/FVim"
-logger "FVim: executable path is: $fvim_exe"
-logger "FVim: arguments are: $@"
 $fvim_exe $@


### PR DESCRIPTION
When `:terminal` is executed it should pick whatever is alredy on `$SHELL` because:

1. on macOS Catalina the default is ZSH (previously was Bash), and
2. Some users don't use the default shell anyway.

This commit removes the hardcoded reference to Bash and uses `path_helper(8)` to get a `$PATH` value and ensure that the launcher works.

Regarding [Bash installed with Homebrew](https://github.com/yatli/fvim/issues/126#issuecomment-596185689) I'm pretty sure the reason FVim wasn't picking up the newer version is the user didn't switch to it using `chsh`. As long as [that procedure](https://akrabat.com/upgrading-to-bash-4-on-macos/) is followed this PR should pick the newer version.