### PR TITLE
Fix for bad Windows shell integration

### DIFF
--- a/shell.fs
+++ b/shell.fs
@@ -81,7 +81,7 @@ let private win32RegisterFileAssociation() =
             _edit.SetValue("", "Open with FVim")
             _edit.SetValue("Icon", fvicon)
             use command = _edit.CreateSubKey("command")
-            command.SetValue("", $"\{exe}\" \"%%1\"")
+            command.SetValue("", $"{exe}\" \"%%1\"")
     
     // https://docs.microsoft.com/en-us/windows/desktop/shell/app-registration
     do


### PR DESCRIPTION
the setup process doesn't integrate with the shell properly. 

trying to open with the context menu gives this error dialog
![image](https://user-images.githubusercontent.com/55286472/174404139-952199e2-c66c-4e73-91b6-af684a3a1698.png)

i found the problem, after a bit. 

the registry value it gives ends up having a slash before the filepath to fvim 
so it would be something like 
"\C:\Fvim\Fvim.exe" "%1" 
instead of 
"C:\Fvim\Fvim.exe" "%1"

changing to the second version in my registry editor does actually fix the problem.