### PR TITLE
Simplify fvim-osx-launcher

### DIFF
--- a/lib/fvim-osx-launcher
+++ b/lib/fvim-osx-launcher
@@ -1,23 +1,7 @@
 #!/usr/bin/env bash
-ENVVARS=""
-set -f
-IFS=$'\n'
-for VAR in `$SHELL --login -c /usr/bin/env`
-do
-  if [[ $VAR == *"="* ]]
-  then
-    if [[ $VAR == "PATH="* ]]
-    then
-      THISPATH=$VAR
-    else
-      ENVVARS="$ENVVARS $VAR"
-    fi
-  fi
-done
-# Put PATH at the beginning to workaround env size limitation
-ENVVARS="$THISPATH $ENVVARS"
+
 fvim_exe="$(dirname "$0")/FVim"
-logger "FVim: Starting. env is: $ENVVARS"
 logger "FVim: executable path is: $fvim_exe"
 logger "FVim: arguments are: $@"
-/usr/bin/env -i $ENVVARS $fvim_exe $@
+
+exec "$SHELL" --login -c "$fvim_exe $@"


### PR DESCRIPTION
Hello,

I had a few issues with `HOME` not being available in environment on a M1 Mac running Ventura and it got me testing things in the launcher. I found the whole "environment variable extracting" deal a bit complex for what it seems to want to do.

I got fvim working fine after tuning a bit the file to just use exec to directly launch fvim from a login shell; so I'm sharing my modifications in case that's something you'd want to include (I'm not sure it will be good for all installations though).

Cheers,

Gerry