### PR TITLE
Update to net8.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
         "type": "coreclr",
         "request": "launch",
         "preLaunchTask": "build",
-        "program": "${workspaceFolder}/bin/Debug/net6.0/FVim.dll",
+        "program": "${workspaceFolder}/bin/Debug/net8.0/FVim.dll",
         "args": ["--daemon"],
         "cwd": "${workspaceFolder}",
         "stopAtEntry": false,

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Cross platform Neovim front-end UI, built with [F#](https://fsharp.org/) + [Aval
     - Arch Linux:  [Install via AUR](https://aur.archlinux.org/packages/fvim/)
     - RPM-based distributions: `rpm -ivh fvim_package_name.rpm`
     - Fedora: `dnf install fvim_package_name.rpm`
-    - Compile from Source (having dotnet-sdk-6.0.x installed):
+    - Compile from Source (having dotnet-sdk-8.0.x installed):
         ```
-            git clone https://github.com/yatli/fvim && cd fvim && dotnet publish -f net6.0 -c Release -r linux-x64 --self-contained
+            git clone https://github.com/yatli/fvim && cd fvim && dotnet publish -f net8.0 -c Release -r linux-x64 --self-contained
         ```
 
 ### Features
@@ -88,7 +88,7 @@ Custom popup menu entry icons (see below for how to configure):
 
 
 ### Building from source
-We're now targeting `net6.0` so make sure to install the latest preview SDK from the [.NET site](https://dotnet.microsoft.com/download/dotnet/6.0).
+We're now targeting `net8.0` so make sure to install the latest SDK from the [.NET site](https://dotnet.microsoft.com/download/dotnet/8.0).
 We're actively tracking the head of `Avalonia`, and fetch the nightly packages from myget (see `NuGet.config`).
 
 Then, simply:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
     inputs:
       packageType: sdk
       includePreviewVersions: false
-      version: 6.0.x
+      version: 8.0.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: NuGetToolInstaller@1
   - task: PowerShell@2
@@ -37,7 +37,7 @@ jobs:
     inputs:
       packageType: sdk
       includePreviewVersions: false
-      version: 6.0.x
+      version: 8.0.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: NuGetToolInstaller@1
   - task: PowerShell@2
@@ -58,7 +58,7 @@ jobs:
     inputs:
       packageType: sdk
       includePreviewVersions: false
-      version: 6.0.x
+      version: 8.0.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: NuGetToolInstaller@1
   - task: PowerShell@2
@@ -80,7 +80,7 @@ jobs:
     inputs:
       packageType: sdk
       includePreviewVersions: false
-      version: 6.0.x
+      version: 8.0.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: Bash@3
     inputs:
@@ -107,7 +107,7 @@ jobs:
     inputs:
       packageType: sdk
       includePreviewVersions: false
-      version: 6.0.x
+      version: 8.0.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: Bash@3
     inputs:
@@ -135,7 +135,7 @@ jobs:
     inputs:
       packageType: sdk
       includePreviewVersions: false
-      version: 6.0.x
+      version: 8.0.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: Bash@3
     inputs:
@@ -156,7 +156,7 @@ jobs:
     inputs:
       packageType: sdk
       includePreviewVersions: false
-      version: 6.0.x
+      version: 8.0.x
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: Bash@3
     inputs:

--- a/fvim.fsproj
+++ b/fvim.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>FVim</AssemblyName>
     <Prefer32Bit>false</Prefer32Bit>
     <ApplicationIcon>Assets\fvim.ico</ApplicationIcon>

--- a/pack.ps1
+++ b/pack.ps1
@@ -8,17 +8,17 @@ Remove-Item -Recurse -Force bin\ -ErrorAction SilentlyContinue
 Remove-Item publish\*
 
 foreach($i in $plat) {
-    dotnet publish -f net6.0 -c Release --self-contained -r $i fvim.fsproj
+    dotnet publish -f net8.0 -c Release --self-contained -r $i fvim.fsproj
     if ($i -eq "win-x64") {
 # replace the coreclr hosting exe with an icon-patched one
-        Copy-Item lib/fvim-win10.exe bin/Release/net6.0/$i/publish/FVim.exe
+        Copy-Item lib/fvim-win10.exe bin/Release/net8.0/$i/publish/FVim.exe
 # Avalonia 0.10.0-preview6 fix: manually copy ANGLE from win7-x64
-        Copy-Item ~/.nuget/packages/avalonia.angle.windows.natives/2.1.0.2020091801/runtimes/win7-x64/native/av_libglesv2.dll bin/Release/net6.0/$i/publish/
+        Copy-Item ~/.nuget/packages/avalonia.angle.windows.natives/2.1.0.2020091801/runtimes/win7-x64/native/av_libglesv2.dll bin/Release/net8.0/$i/publish/
     } elseif ($i -eq "win7-x64") {
-        Copy-Item lib/fvim-win7.exe bin/Release/net6.0/$i/publish/FVim.exe
+        Copy-Item lib/fvim-win7.exe bin/Release/net8.0/$i/publish/FVim.exe
     } elseif ($i -eq "win-arm64") {
-        Copy-Item lib/fvim-win10-arm64.exe bin/Release/net6.0/$i/publish/FVim.exe
+        Copy-Item lib/fvim-win10-arm64.exe bin/Release/net8.0/$i/publish/FVim.exe
     }
-    Compress-Archive -Path bin/Release/net6.0/$i/publish/* -DestinationPath publish/fvim-$i.zip -Force
+    Compress-Archive -Path bin/Release/net8.0/$i/publish/* -DestinationPath publish/fvim-$i.zip -Force
 }
 

--- a/pack.sh
+++ b/pack.sh
@@ -12,8 +12,8 @@ rm -ir publish/*
 PKG_TFM=$1
 VERSION=$(git describe)
 VERSION=${VERSION:1}
-PKG_ROOT="bin/Release/net6.0/$PKG_TFM/publish"
-dotnet publish -f net6.0 -c Release --self-contained -r $PKG_TFM fvim.fsproj
+PKG_ROOT="bin/Release/net8.0/$PKG_TFM/publish"
+dotnet publish -f net8.0 -c Release --self-contained -r $PKG_TFM fvim.fsproj
 
 function pack-linux-x64()
 {

--- a/update.ps1
+++ b/update.ps1
@@ -1,6 +1,6 @@
 Stop-Process -Name "fvim"
-dotnet publish -f net6.0 -c Release --self-contained -r win-x64 fvim.fsproj
-cp bin/Release/net6.0/win-x64/publish/FVim* C:/tools/fvim/
+dotnet publish -f net8.0 -c Release --self-contained -r win-x64 fvim.fsproj
+cp bin/Release/net8.0/win-x64/publish/FVim* C:/tools/fvim/
 cp lib/fvim-win10.exe C:/tools/fvim/FVim.exe
 cp fvim.vim C:/tools/fvim/fvim.vim
 fvim

--- a/update.sh
+++ b/update.sh
@@ -3,4 +3,4 @@
 pkill FVim
 dotnet build -c Release fvim.fsproj
 sudo rm -rf /usr/share/fvim/*
-sudo cp -r bin/Release/net6.0/* /usr/share/fvim/
+sudo cp -r bin/Release/net8.0/* /usr/share/fvim/


### PR DESCRIPTION
.NET 6 is several years old, in fact .NET 9 just came out. I don't actually have a .NET 6.0 SDK on my Linux dev machine, so in order to build FVim I had to update everything to target net8.0 rather than net6.0. (Or hunt for old SDK packages I could install, but it was easier to just update the target frameworks).

Everything built and ran just fine after the update, so I figured I might as well make a PR in case you want to pull this change in.

This doesn't update any NuGet packages, incidentially. There are several packages that `dotnet restore` warns about, so I'll probably make another PR updating those at some point.